### PR TITLE
Feat/sponsor news

### DIFF
--- a/locales/en/sponsor.json
+++ b/locales/en/sponsor.json
@@ -13,6 +13,7 @@
     "silver": "Silver Sponsor",
     "bronze": "Bronze Sponsor",
     "co-organizer": "Co-Organizer",
-    "special-thanks": "Special Thanks"
+    "special-thanks": "Special Thanks",
+    "friend": "Friend"
   }
 }

--- a/locales/zh-TW/sponsor.json
+++ b/locales/zh-TW/sponsor.json
@@ -13,6 +13,7 @@
     "silver": "白銀級贊助",
     "bronze": "青銅級贊助",
     "co-organizer": "協辦單位",
-    "special-thanks": "特別感謝"
+    "special-thanks": "特別感謝",
+    "friend": "好朋友"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
       },
       "devDependencies": {
         "@iconify/json": "^1.1.333",
+        "@types/faker": "^5.5.5",
         "@types/google-spreadsheet": "^3.1.1",
         "@types/lodash": "^4.14.157",
         "@types/markdown-it": "^12.0.1",
@@ -54,6 +55,7 @@
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-promise": "^4.3.1",
         "eslint-plugin-vue": "^7.9.0",
+        "faker": "^5.5.3",
         "find": "^0.3.0",
         "google-spreadsheet": "^3.1.15",
         "koa": "^2.13.0",
@@ -603,6 +605,12 @@
       "version": "10.4.4",
       "resolved": "https://registry.npmjs.org/@types/arcgis-rest-api/-/arcgis-rest-api-10.4.4.tgz",
       "integrity": "sha512-5NwSfj4po+03fauyr4F5AxYzu8pbbqmxay+pNr5ef2V3Mj+7OylvV48VKuVoO9m799jhZdH3EQgQBHm3Y6q1Sw==",
+      "dev": true
+    },
+    "node_modules/@types/faker": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.5.tgz",
+      "integrity": "sha512-TNR5SjCg8sSfU4bdXsPJlpLXOH4YGBCVggvdZnttD2SMiONSxfJm231Nxn1VaQWWF2Twl4Wr2KC1hYaNd4M5Zw==",
       "dev": true
     },
     "node_modules/@types/geojson": {
@@ -4138,6 +4146,12 @@
       "engines": [
         "node >=0.6.0"
       ]
+    },
+    "node_modules/faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
+      "dev": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -11528,6 +11542,12 @@
       "integrity": "sha512-5NwSfj4po+03fauyr4F5AxYzu8pbbqmxay+pNr5ef2V3Mj+7OylvV48VKuVoO9m799jhZdH3EQgQBHm3Y6q1Sw==",
       "dev": true
     },
+    "@types/faker": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/@types/faker/-/faker-5.5.5.tgz",
+      "integrity": "sha512-TNR5SjCg8sSfU4bdXsPJlpLXOH4YGBCVggvdZnttD2SMiONSxfJm231Nxn1VaQWWF2Twl4Wr2KC1hYaNd4M5Zw==",
+      "dev": true
+    },
     "@types/geojson": {
       "version": "7946.0.7",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.7.tgz",
@@ -14476,6 +14496,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
       "dev": true
     },
     "fast-deep-equal": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   },
   "devDependencies": {
     "@iconify/json": "^1.1.333",
+    "@types/faker": "^5.5.5",
     "@types/google-spreadsheet": "^3.1.1",
     "@types/lodash": "^4.14.157",
     "@types/markdown-it": "^12.0.1",
@@ -64,6 +65,7 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.3.1",
     "eslint-plugin-vue": "^7.9.0",
+    "faker": "^5.5.3",
     "find": "^0.3.0",
     "google-spreadsheet": "^3.1.15",
     "koa": "^2.13.0",

--- a/scripts/pre-build/generateSponsor.ts
+++ b/scripts/pre-build/generateSponsor.ts
@@ -1,7 +1,8 @@
 import axios from 'axios'
+import { company, internet, lorem } from 'faker'
 import { getSheetRows, saveJSON } from './utils'
 
-import type { SponsorLevel, SponsorLevelRow, SponsorRow, SponsorNewsRow } from './types'
+import type { SponsorLevelTuple, SponsorLevel, SponsorLevelRow, SponsorRow, SponsorNewsRow } from './types'
 import type { GoogleSpreadsheet } from 'google-spreadsheet'
 
 async function fetchRemoteSponsorData () {
@@ -60,7 +61,10 @@ function transformSponsorNews (rows: SponsorNewsRow[], sponsorLevelMap: ReturnTy
     .filter((r) => !!sponsorMap[r.sponsor])
     .map((r) => ({
       sponsor: r.sponsor,
-      image: r.image,
+      image: {
+        vertical: r['image:vertical'],
+        horizontal: r['image:horizontal']
+      },
       description: r.description,
       link: r.link,
       weight: (r.specialWeight.length === 0 || isNaN(Number(r.specialWeight)))
@@ -69,10 +73,110 @@ function transformSponsorNews (rows: SponsorNewsRow[], sponsorLevelMap: ReturnTy
     }))
 }
 
-export default async function generateSponsor (doc: GoogleSpreadsheet | null) {
+function transformData (sponsorLevelRows: SponsorLevelRow[], sponsorRows: SponsorRow[], sponsorNewsRows: SponsorNewsRow[]) {
+  const sponsorLevelMap = transformSponsorLevelMap(sponsorLevelRows)
+  const sponsorMap = transformSponsorMap(sponsorRows)
+  const sponsorNews = transformSponsorNews(sponsorNewsRows, sponsorLevelMap, sponsorMap)
+
+  const sponsorData = Object.values(sponsorMap)
+  const sponsorNewsData = sponsorNews
+  return [sponsorData, sponsorNewsData] as const
+}
+
+function createFakeData () {
+  const sponsorLevelRows: SponsorLevelRow[] = [
+    {
+      level: 'titanium',
+      basicWeight: '64'
+    },
+    {
+      level: 'diamond',
+      basicWeight: '32'
+    },
+    {
+      level: 'gold',
+      basicWeight: '16'
+    },
+    {
+      level: 'silver',
+      basicWeight: '8'
+    },
+    {
+      level: 'bronze',
+      basicWeight: '4'
+    },
+    {
+      level: 'special-thanks',
+      basicWeight: '2'
+    },
+    {
+      level: 'co-organizer',
+      basicWeight: '1'
+    },
+    {
+      level: 'friend',
+      basicWeight: '0'
+    }
+  ]
+  const sponsorRows: SponsorRow[] = (() => {
+    const numOfSponsorsMap: Record<SponsorLevel, number> = {
+      titanium: 3,
+      diamond: 5,
+      gold: 8,
+      silver: 4,
+      bronze: 13,
+      'special-thanks': 3,
+      'co-organizer': 2,
+      friend: 3
+    }
+    const sponsorRowsMap =
+      Object.fromEntries((['titanium', 'diamond', 'co-organizer', 'gold', 'bronze', 'silver', 'special-thanks', 'friend'] as SponsorLevelTuple)
+        .map((level) => {
+          const entry: [SponsorLevel, SponsorRow[]] = [
+            level as SponsorLevel,
+            Array.from(Array(numOfSponsorsMap[level]), (_, i): SponsorRow => ({
+              sponsor: `${level}-${i}`,
+              level,
+              'name:en': company.companyName(),
+              'name:zh-TW': company.companyName(),
+              'intro:en': lorem.paragraphs(2),
+              'intro:zh-TW': lorem.paragraphs(2),
+              link: internet.url(),
+              image: `https://picsum.photos/600/400?random=${Math.random()}`,
+              canPublish: 'Y'
+            }))
+          ]
+          return entry
+        })
+      ) as Record<SponsorLevel, SponsorRow[]>
+    return Object.values(sponsorRowsMap).flat()
+  })()
+  const sponsorNewsRows: SponsorNewsRow[] = (() => {
+    return sponsorRows
+      .map((r): SponsorNewsRow => {
+        return {
+          sponsor: r.sponsor,
+          'image:vertical': `https://picsum.photos/200/800?random=${Math.random()}`,
+          'image:horizontal': `https://picsum.photos/1440/400?random=${Math.random()}`,
+          description: lorem.paragraph(4),
+          link: internet.url(),
+          specialWeight: '',
+          canPublish: 'Y'
+        }
+      })
+  })()
+
+  return transformData(sponsorLevelRows, sponsorRows, sponsorNewsRows)
+}
+
+export default async function generateSponsor (doc: GoogleSpreadsheet | null, fake = false) {
   let sponsorData: unknown
   let sponsorNewsData: unknown
-  if (doc === null) {
+  if (fake) {
+    const [d1, d2] = createFakeData()
+    sponsorData = d1
+    sponsorNewsData = d2
+  } else if (doc === null) {
     sponsorData = await fetchRemoteSponsorData()
     sponsorNewsData = await fetchRemoteSponsorNewsData()
   } else {
@@ -81,12 +185,9 @@ export default async function generateSponsor (doc: GoogleSpreadsheet | null) {
       getSheetRows(doc, 'sponsor'),
       getSheetRows(doc, 'sponsorNews')
     ])
-    const sponsorLevelMap = transformSponsorLevelMap(sponsorLevelRows)
-    const sponsorMap = transformSponsorMap(sponsorRows)
-    const sponsorNews = transformSponsorNews(sponsorNewsRows, sponsorLevelMap, sponsorMap)
-
-    sponsorData = Object.values(sponsorMap)
-    sponsorNewsData = sponsorNews
+    const [d1, d2] = transformData(sponsorLevelRows, sponsorRows, sponsorNewsRows)
+    sponsorData = d1
+    sponsorNewsData = d2
   }
   saveJSON('sponsor', sponsorData)
   saveJSON('sponsor-news', sponsorNewsData)

--- a/scripts/pre-build/generateSponsor.ts
+++ b/scripts/pre-build/generateSponsor.ts
@@ -67,6 +67,7 @@ function transformSponsorNews (rows: SponsorNewsRow[], sponsorLevelMap: ReturnTy
       },
       description: r.description,
       link: r.link,
+      level: sponsorMap[r.sponsor].level,
       weight: (r.specialWeight.length === 0 || isNaN(Number(r.specialWeight)))
         ? sponsorLevelMap[sponsorMap[r.sponsor].level].basicWeight
         : Number(r.specialWeight)

--- a/scripts/pre-build/index.ts
+++ b/scripts/pre-build/index.ts
@@ -16,7 +16,7 @@ import generateStaff from './generateStaff'
     const doc = await getLoadedSpreadsheetDocument()
     await Promise.all([
       generateAnnouncement(doc),
-      generateSponsor(doc),
+      generateSponsor(doc, true),
       generateSession(),
       generateStaff()
     ])

--- a/scripts/pre-build/types.ts
+++ b/scripts/pre-build/types.ts
@@ -1,7 +1,8 @@
 type AnnouncementRowKeys = 'uuid' | 'meta:title:en' | 'meta:title:zh-TW' | 'meta:description:en' | 'meta:description:zh-TW' | 'content:en' | 'content:zh-TW'
 export type AnnouncementRow = Record<AnnouncementRowKeys, string>
 
-export type SponsorLevel = 'titanium' | 'diamond' | 'co-organizer' | 'gold' | 'bronze' | 'silver' | 'special-thanks' | 'friend'
+export type SponsorLevelTuple = ['titanium', 'diamond', 'co-organizer', 'gold', 'bronze', 'silver', 'special-thanks', 'friend']
+export type SponsorLevel = SponsorLevelTuple[number]
 type SponsorLevelRowKeys = 'level' | 'basicWeight'
 export type SponsorLevelRow = {
   [K in SponsorLevelRowKeys]: K extends 'level' ? SponsorLevel : string;
@@ -16,7 +17,7 @@ export type SponsorRow = {
       : string;
 }
 
-type SponsorNewsRowKeys = 'sponsor' | 'description' | 'link' | 'image' | 'specialWeight' | 'canPublish'
+type SponsorNewsRowKeys = 'sponsor' | 'description' | 'link' | 'image:vertical' | 'image:horizontal' | 'specialWeight' | 'canPublish'
 export type SponsorNewsRow = {
   [K in SponsorNewsRowKeys]: K extends 'canPublish'
     ? 'Y' | 'N'

--- a/src/components/App/SponsorFooter.vue
+++ b/src/components/App/SponsorFooter.vue
@@ -43,12 +43,12 @@ import sponsorDatas from '@/assets/json/sponsor.json'
 import { defineComponent, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { Locale } from '@/modules/i18n'
-import { generateAssetsMap } from '@/utils/common'
+// import { generateAssetsMap } from '@/utils/common'
 
-const imagesMap = generateAssetsMap(
-  import.meta.globEager('../../assets/images/sponsors/*.png'),
-  '../../assets/images/sponsors/*.png'
-)
+// const imagesMap = generateAssetsMap(
+//   import.meta.globEager('../../assets/images/sponsors/*.png'),
+//   '../../assets/images/sponsors/*.png'
+// )
 
 export default defineComponent({
   name: 'SponsorFooter',
@@ -60,7 +60,8 @@ export default defineComponent({
         id: data.id,
         name: data.name[locale.value as Locale],
         link: data.link,
-        image: imagesMap[data.image]
+        image: data.image
+        // image: imagesMap[data.image]
       }
     }), 'level'))
       .sort((entryA, entryB) => {

--- a/src/modules/pop-up/components/Container/SessionPopUpContainer.vue
+++ b/src/modules/pop-up/components/Container/SessionPopUpContainer.vue
@@ -12,15 +12,18 @@
     @click.self="$emit('close')"
   >
     <a
-      v-if="news.verticalLeft"
+      v-if="news"
       class="sponsor-news vertical"
       :href="news.verticalLeft.link"
       target="_blank"
       rel="noopener noreferrer"
     >
-      <img
-        :data-src="imagesMap[`${news.verticalLeft.sponsor}/vertical.png`]"
+      <!-- <img
         :src="imagesMap[`${news.verticalLeft.sponsor}/vertical.png`]"
+        :alt="`${news.verticalLeft.sponsor}'s news`"
+      /> -->
+      <img
+        :src="news.verticalLeft.image.vertical"
         :alt="`${news.verticalLeft.sponsor}'s news`"
       />
     </a>
@@ -31,26 +34,34 @@
       <slot></slot>
     </div>
     <a
-      v-if="news.horizontalBottom"
+      v-if="news"
       class="sponsor-news horizontal"
       :href="news.horizontalBottom.link"
       target="_blank"
       rel="noopener noreferrer"
     >
-      <img
+      <!-- <img
         :src="imagesMap[`${news.horizontalBottom.sponsor}/horizontal.png`]"
+        :alt="`${news.horizontalBottom.sponsor}'s news`"
+      /> -->
+      <img
+        :src="news.horizontalBottom.image.horizontal"
         :alt="`${news.horizontalBottom.sponsor}'s news`"
       />
     </a>
     <a
-      v-if="news.verticalRight"
+      v-if="news"
       class="sponsor-news vertical"
       :href="news.verticalRight.link"
       target="_blank"
       rel="noopener noreferrer"
     >
-      <img
+      <!-- <img
         :src="imagesMap[`${news.verticalRight.sponsor}/vertical.png`]"
+        :alt="`${news.verticalRight.sponsor}'s news`"
+      /> -->
+      <img
+        :src="news.verticalRight.image.vertical"
         :alt="`${news.verticalRight.sponsor}'s news`"
       />
     </a>
@@ -58,43 +69,80 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, onBeforeMount, reactive } from 'vue'
+import { defineComponent, onBeforeMount, ref } from 'vue'
 import sponsorNewsData from '@/assets/json/sponsor-news.json'
-import { generateAssetsMap } from '@/utils/common'
+// import { generateAssetsMap } from '@/utils/common'
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType[number];
 type NewsData = ArrayElement<typeof sponsorNewsData>
 
 interface NewsList {
-  verticalLeft: NewsData | null;
-  verticalRight: NewsData | null;
-  horizontalBottom: NewsData | null;
+  verticalLeft: NewsData;
+  verticalRight: NewsData;
+  horizontalBottom: NewsData;
 }
 
-const imagesMap = generateAssetsMap(
-  import.meta.globEager('../../../../assets/images/sponsor-news/*/*.png'),
-  '../../../../assets/images/sponsor-news/*/*.png'
-)
+// const imagesMap = generateAssetsMap(
+//   import.meta.globEager('../../../../assets/images/sponsor-news/*/*.png'),
+//   '../../../../assets/images/sponsor-news/*/*.png'
+// )
+
+const indexStringLength = sponsorNewsData.length.toString(16).length
+const randomString = sponsorNewsData
+  .map((data, i) => {
+    return i.toString(16)
+      .padStart(indexStringLength, '0')
+      .repeat(data.weight)
+  })
+  .join('')
+function randomNews (): NewsData {
+  const random = Math.floor(Math.random() * (randomString.length / indexStringLength))
+  const result = Number('0x' + randomString.slice(random * indexStringLength, (random + 1) * indexStringLength))
+  return sponsorNewsData[result]
+}
+
+function randomAllNews () {
+  const result: Partial<NewsList> = {
+    horizontalBottom: randomNews()
+  }
+  if (Math.random() < 0.3) {
+    const sponsor = randomNews().sponsor
+    const datas = sponsorNewsData
+      .filter((data) => data.sponsor === sponsor)
+      .sort(() => 0.5 - Math.random())
+    switch (datas.length) {
+      case 0:
+      case 1:
+        result.verticalLeft = datas[0]
+        result.verticalRight = datas[0]
+        break
+
+      default:
+        result.verticalLeft = datas[0]
+        result.verticalRight = datas[1]
+        break
+    }
+  } else {
+    // Random 2 news
+    result.verticalLeft = randomNews()
+    result.verticalRight = randomNews()
+  }
+
+  return result as NewsList
+}
 
 export default defineComponent({
   name: 'SessionPopupContainer',
   setup () {
-    const news: NewsList = reactive({
-      verticalLeft: null,
-      verticalRight: null,
-      horizontalBottom: null
-    })
+    const news = ref<NewsList | null>(null)
 
     onBeforeMount(() => {
-      const numOfAds = sponsorNewsData.length
-      news.verticalLeft = sponsorNewsData[Math.floor(Math.random() * numOfAds)]
-      news.verticalRight = sponsorNewsData[Math.floor(Math.random() * numOfAds)]
-      news.horizontalBottom = sponsorNewsData[Math.floor(Math.random() * numOfAds)]
+      news.value = randomAllNews()
     })
 
     return {
-      news,
-      imagesMap
+      // imagesMap,
+      news
     }
   }
 })

--- a/src/modules/session/index.ts
+++ b/src/modules/session/index.ts
@@ -37,7 +37,6 @@ const _useSession = (): UseSession => {
 
   const load = async () => {
     if (isLoaded.value) return
-    isLoaded.value = true
     start()
     const { default: _rawData } = await import('@/assets/json/session.json')
     const { scheduleElements: _scheduleElements, sessionsMap: _sessionsMap, roomsMap: _roomsMap } =
@@ -45,6 +44,7 @@ const _useSession = (): UseSession => {
     scheduleElements.value = _scheduleElements
     sessionsMap.value = _sessionsMap
     roomsMap.value = _roomsMap
+    isLoaded.value = true
     done()
   }
 

--- a/src/pages/Sponsor.vue
+++ b/src/pages/Sponsor.vue
@@ -69,16 +69,16 @@ import { useBreakpoints } from '@/modules/breakpoints'
 import { Locale } from '@/modules/i18n'
 import { useI18n } from 'vue-i18n'
 import { isClient } from '@vueuse/core'
-import { generateAssetsMap } from '@/utils/common'
+// import { generateAssetsMap } from '@/utils/common'
 
 type ArrayElement<ArrayType extends readonly unknown[]> = ArrayType[number];
 type SopnsorData = ArrayElement<typeof sponsorDatas>
 type SponsorGroups = Record<string, SopnsorData[]>
 
-const imagesMap = generateAssetsMap(
-  import.meta.globEager('../assets/images/sponsors/*.png'),
-  '../assets/images/sponsors/*.png'
-)
+// const imagesMap = generateAssetsMap(
+//   import.meta.globEager('../assets/images/sponsors/*.png'),
+//   '../assets/images/sponsors/*.png'
+// )
 
 export default defineComponent({
   name: 'Sponsor',
@@ -93,14 +93,15 @@ export default defineComponent({
       sponsorGroups.value = Object.fromEntries(
         await Promise.all(Object.entries(groupBy<SopnsorData>(sponsorDatas, 'level'))
           .sort((entryA, entryB) => {
-            const sponsorSequence = ['titanium', 'diamond', 'gold', 'silver', 'bronze', 'co-organizer', 'special-thanks']
+            const sponsorSequence = ['titanium', 'diamond', 'gold', 'silver', 'bronze', 'co-organizer', 'special-thanks', 'friend']
             return sponsorSequence.indexOf(entryA[0]) - sponsorSequence.indexOf(entryB[0])
           })
           .map(async ([group, rawSponsors]) => {
             const sponsors = await Promise.all(rawSponsors.map(async (rawSponsor) => {
               const sponsor: SopnsorData = {
-                ...rawSponsor,
-                image: imagesMap[rawSponsor.image]
+                // ...rawSponsor,
+                // image: imagesMap[rawSponsor.image]
+                ...rawSponsor
               }
 
               sponsor.intro = {


### PR DESCRIPTION
主要是要做贊助商廣告的功能

## 桌面版介面有兩側廣告
- 30%機率左右同時顯示相同贊助商（鈦金或鑽石）廣告
    - 以60%對40%機率決定鈦金或鑽石廠商，決定完等級後隨機決定一家同等級廠商，若該贊助商有 >= 2 個廣告則 shuffled 後取兩個於左右顯示

- 70%機率左右顯示不同廣告
    - 權重隨機抽出兩個要顯示的贊助商廣告

## 手機版介面只有底部一處廣告位置
- 權重隨機抽出兩個要顯示的贊助商廣告

---

- 由於目前還沒有任何真實資料，所以就自己產 fake data
- 隨機贊助商廣告流程放在 `src/modules/pop-up/components/Container/SessionPopUpContainer.vue` 裡
- 順便發現修正 session 在 load 資料時的流程錯誤

要測的話記得打開允許其他頁面（.env 裡 VITE_LANDING_ONLY=no）