### PR TITLE
fix: 如果補件的人沒辦法取得講者的 email，那講者資料就不能被建立起來，必須從稿件中取得對應資料

### DIFF
--- a/scripts/pre-build/generateSession.ts
+++ b/scripts/pre-build/generateSession.ts
@@ -85,13 +85,17 @@ function genResult (talks, rooms, speakers) {
       language: s.content_locale === 'zh-tw' ? '漢語' : 'English',
       zh: {
         title: s.title,
-        description: (s.answers.find((a :any) => a.question.id === 865) || {}).answer || ""
+        description: (s.answers.find((a :any) => a.question.id === 865) || {}).answer || s.description || ""
       },
       en: {
         title: (s.answers.find((a :any) => a.question.id === 859) || {}).answer || s.title,
-        description: (s.answers.find((a :any) => a.question.id === 860) || {}).answer || ""
+        description: (s.answers.find((a :any) => a.question.id === 860) || {}).answer || (s.answers.find((a :any) => a.question.id === 865) || {}).answer || ""
       },
       speakers: s.speakers.map(ss => ss.code),
+      speakerZhName: (s.answers.find((a :any) => a.question.id === 863) || {}).answer || '',
+      speakerEnName: (s.answers.find((a :any) => a.question.id === 861) || {}).answer || '',
+      speakerZhBio: (s.answers.find((a :any) => a.question.id === 866) || {}).answer || '',
+      speakerEnBio: (s.answers.find((a :any) => a.question.id === 862) || {}).answer || '',
       tags: s.answers.find(a => a.question.id === 876) !== undefined ? [s.answers.find(a => a.question.id === 876).options[0].answer.en] : [],
       co_write: s.answers.find(a => a.question.id === 550) !== undefined ? s.answers.find(a => a.question.id === 550).answer : null,
       slide: s.answers.find(a => a.question.id === 566) !== undefined ? s.answers.find(a => a.question.id === 566).answer : null,

--- a/src/modules/session/logic.ts
+++ b/src/modules/session/logic.ts
@@ -73,7 +73,24 @@ export function transformRawData (rawData: RawData, timeZoneOffsetMinutes: numbe
       return { ...rest, 'zh-TW': zh }
     })()
     const speakers = ((): Speaker[] => {
-      return rawRest.speakers.map(s => rawData.speakers.find(d => d.id === s)!)
+      if (! rawRest.speakers.length && rawRest.speakerZhName !== '') {
+        return [
+          {
+            id,
+            avatar: '',
+            en: {
+              name: rawRest.speakerEnName,
+              bio: rawRest.speakerEnBio
+            },
+            "zh-TW": {
+              name: rawRest.speakerZhName,
+              bio: rawRest.speakerZhBio
+            }
+          }
+        ]
+      }
+      return rawRest.speakers
+        .map(s => rawData.speakers.find(d => d.id === s)!)
         .map(({ zh, ...rest }) => ({ ...rest, 'zh-TW': zh }))
     })()
     const tags = ((): Tag[] => {


### PR DESCRIPTION
### 前言：

1. pretalx 的 proposal question 分成 per speaker 與 per proposal 兩種，差異是會在 speaker 的 api 拿到，還是會在 session 的 api 拿到
2. pretalx 的講者是用 email 當識別，所以如果沒有 email 就不能建立講者

### 情景：

1. 中國軌的講者不一定能連上 pretalx​，那基本上就不能拿他們的 email 要求他們填寫講者資料
2. 但 pretalx 如果沒有 email ​，就不能建立講者，就不能填寫 per speaker 的 question
3. 所以我暫時把一些問題從 per speaker 改成 per proposal​
4. 官網上要改的是，如果沒有 speaker 的資料，就試著從 session 裡抓資料